### PR TITLE
mocked posthog in testing and accept project key as param

### DIFF
--- a/src/ploomber_core/telemetry/telemetry.py
+++ b/src/ploomber_core/telemetry/telemetry.py
@@ -388,20 +388,21 @@ def validate_entries(event_id, uid, action, client_time, total_runtime):
 
 class Telemetry:
     def __init__(self, api_key, package_name, version):
+        """
+        package_name is the name of the package calling the function.
+        version is the running version of that pacakge.
+        api_key is the api_key for the posthog project.
+        """
         self.api_key = api_key
         self.version = version
         self.package_name = package_name
 
-
     def log_api(self, action, client_time=None,
                 total_runtime=None, metadata=None):
         """
-        This function logs through an API call, assigns parameters if missing like
-        timestamp, event id and stats information.
+        This function logs through an API call, assigns parameters
+        if missing like timestamp, event id and stats information.
 
-        pkn is the name of the package calling the function, such as 'ploomber'.
-        ver is the running version of that pacakge, for example '0.14.0'.
-        key is the api_key for the posthog project related to that package.
         """
 
         posthog.project_api_key = self.api_key
@@ -454,8 +455,10 @@ class Telemetry:
 
         if telemetry_enabled and online:
             (event_id, uid, action, client_time,
-            elapsed_time) = validate_entries(event_id, uid, action, client_time,
-                                            total_runtime)
+             elapsed_time) = validate_entries(event_id,
+                                              uid, action,
+                                              client_time,
+                                              total_runtime)
             props = {
                 'event_id': event_id,
                 'user_id': uid,
@@ -481,7 +484,6 @@ class Telemetry:
 
             posthog.capture(distinct_id=uid, event=action, properties=props)
 
-
     # NOTE: should we log differently depending on the error type?
     # NOTE: how should we handle chained exceptions?
     def log_call(self, action, payload=False):
@@ -497,7 +499,7 @@ class Telemetry:
             def wrapper(*args, **kwargs):
                 _payload = dict()
                 self.log_api(action=f'{action}-started',
-                        metadata={'argv': sys.argv})
+                             metadata={'argv': sys.argv})
                 start = datetime.datetime.now()
 
                 try:
@@ -518,12 +520,12 @@ class Telemetry:
                         })
                     raise e
                 else:
-                    self.log_api(action=f'{action}-success',
-                            total_runtime=str(datetime.datetime.now() - start),
-                            metadata={
-                                'argv': sys.argv,
-                                **_payload
-                            })
+                    self.log_api(
+                         action=f'{action}-success',
+                         total_runtime=str(datetime.datetime.now() - start),
+                         metadata={
+                            'argv': sys.argv,
+                            **_payload})
 
                 return result
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,8 @@ import shutil
 import os
 import pytest
 import tempfile
+import posthog
+from unittest.mock import MagicMock
 
 
 @pytest.fixture()
@@ -16,3 +18,26 @@ def tmp_directory():
 
     # ignore unexpected permission error during test suite cleanup
     shutil.rmtree(str(tmp), ignore_errors=True)
+
+
+@pytest.fixture(scope='class')
+def monkeypatch_session():
+    from _pytest.monkeypatch import MonkeyPatch
+    m = MonkeyPatch()
+    yield m
+    m.undo()
+
+
+@pytest.fixture(scope='class', autouse=True)
+def external_access(request, monkeypatch_session):
+    # https://miguendes.me/pytest-disable-autouse
+    if 'allow_posthog' in request.keywords:
+        yield
+    else:
+        # https://github.com/pytest-dev/pytest/issues/7061#issuecomment-611892868
+        external_access = MagicMock()
+        external_access.get_something = MagicMock(
+            return_value='Mock was used.')
+        monkeypatch_session.setattr(posthog, 'capture',
+                                    external_access.get_something)
+        yield

--- a/tests/telemetry/test_telemetry.py
+++ b/tests/telemetry/test_telemetry.py
@@ -274,8 +274,8 @@ def test_stats_off(monkeypatch):
     posthog_mock = Mock()
     mock.patch(telemetry, '_get_telemetry_info', (False, 'TestUID'))
 
-    telemetry_instance = telemetry.Telemetry('ploomber', '0.14.0', MOCK_API_KEY)
-    telemetry_instance.log_api("test_action")
+    _telemetry = telemetry.Telemetry('ploomber', '0.14.0', MOCK_API_KEY)
+    _telemetry.log_api("test_action")
 
     assert posthog_mock.call_count == 0
 
@@ -285,8 +285,8 @@ def test_offline_stats(monkeypatch):
     posthog_mock = Mock()
     mock.patch(telemetry, 'is_online', False)
 
-    telemetry_instance = telemetry.Telemetry('ploomber', '0.14.0', MOCK_API_KEY)
-    telemetry_instance.log_api("test_action")
+    _telemetry = telemetry.Telemetry('ploomber', '0.14.0', MOCK_API_KEY)
+    _telemetry.log_api("test_action")
 
     assert posthog_mock.call_count == 0
 
@@ -425,9 +425,9 @@ def mock_telemetry(monkeypatch):
 
 
 def test_log_call_success(mock_telemetry):
-    telemetry_instance = telemetry.Telemetry('ploomber', '0.14.0', MOCK_API_KEY)
-    
-    @telemetry_instance.log_call('some-action')
+    _telemetry = telemetry.Telemetry('ploomber', '0.14.0', MOCK_API_KEY)
+
+    @_telemetry.log_call('some-action')
     def my_function():
         pass
 
@@ -443,8 +443,9 @@ def test_log_call_success(mock_telemetry):
 
 
 def test_log_call_exception(mock_telemetry):
-    telemetry_instance = telemetry.Telemetry('ploomber', '0.14.0', MOCK_API_KEY)
-    @telemetry_instance.log_call('some-action')
+    _telemetry = telemetry.Telemetry('ploomber', '0.14.0', MOCK_API_KEY)
+
+    @_telemetry.log_call('some-action')
     def my_function():
         raise ValueError('some error')
 
@@ -465,9 +466,9 @@ def test_log_call_exception(mock_telemetry):
 
 
 def test_log_call_logs_type(mock_telemetry):
-    telemetry_instance = telemetry.Telemetry('ploomber', '0.14.0', MOCK_API_KEY)
+    _telemetry = telemetry.Telemetry('ploomber', '0.14.0', MOCK_API_KEY)
 
-    @telemetry_instance.log_call('some-action')
+    @_telemetry.log_call('some-action')
     def my_function():
         raise BaseException('some error', type_='some-type')
 
@@ -488,9 +489,9 @@ def test_log_call_logs_type(mock_telemetry):
 
 
 def test_log_call_add_payload_error(mock_telemetry):
-    telemetry_instance = telemetry.Telemetry('ploomber', '0.14.0', MOCK_API_KEY)
+    _telemetry = telemetry.Telemetry('ploomber', '0.14.0', MOCK_API_KEY)
 
-    @telemetry_instance.log_call('some-action', payload=True)
+    @_telemetry.log_call('some-action', payload=True)
     def my_function(payload):
         payload['dag'] = 'value'
         raise BaseException('some error', type_='some-type')
@@ -513,9 +514,9 @@ def test_log_call_add_payload_error(mock_telemetry):
 
 
 def test_log_call_add_payload_success(mock_telemetry):
-    telemetry_instance = telemetry.Telemetry('ploomber', '0.14.0', MOCK_API_KEY)
+    _telemetry = telemetry.Telemetry('ploomber', '0.14.0', MOCK_API_KEY)
 
-    @telemetry_instance.log_call('some-action', payload=True)
+    @_telemetry.log_call('some-action', payload=True)
     def my_function(payload):
         payload['dag'] = 'value'
 
@@ -540,9 +541,9 @@ def test_hides_posthog_log(caplog, monkeypatch):
         log.error('some error happened')
 
     monkeypatch.setattr(posthog, 'capture', fake_capture)
-    telemetry_instance = telemetry.Telemetry('ploomber', '0.14.0', MOCK_API_KEY)
+    _telemetry = telemetry.Telemetry('ploomber', '0.14.0', MOCK_API_KEY)
 
     with caplog.at_level(logging.ERROR, logger="posthog"):
-        telemetry_instance.log_api("test_action")
+        _telemetry.log_api("test_action")
 
     assert len(caplog.records) == 0


### PR DESCRIPTION
and the fixture to conftest.py

Added one more parameter to  log call and log_api: posthog project api key

I think this way each package now has their own data separated? 