### PR TITLE
telemetry duplications fixed

### DIFF
--- a/src/ploomber_core/config.py
+++ b/src/ploomber_core/config.py
@@ -1,7 +1,7 @@
 import warnings
 import abc
 from collections.abc import Mapping
-
+from pathlib import Path
 import yaml
 
 
@@ -44,10 +44,10 @@ class Config(abc.ABC):
 
     def _load_from_file(self):
         path = self.path()
-        text = path.read_text()
+        config = self.load_config()
 
-        if text:
-            content = yaml.safe_load(text)
+        if config:
+            content = config
         else:
             # this might happen if using multiprocessing: the first process
             # won't see the file so it'll proceed writing it, but upcoming
@@ -111,6 +111,17 @@ class Config(abc.ABC):
         else:
             super().__setattr__(name, value)
             self._write()
+
+    def load_config(self):
+        config = None
+        path = self.path()
+        is_config_exist = Path.is_file(path)
+        if is_config_exist:
+            text = path.read_text()
+            if text:
+                config = yaml.safe_load(text)
+
+        return config
 
     @abc.abstractclassmethod
     def path(cls):

--- a/src/ploomber_core/telemetry/telemetry.py
+++ b/src/ploomber_core/telemetry/telemetry.py
@@ -83,7 +83,12 @@ class Internal(Config):
         return Path(check_dir_exist(CONF_DIR), DEFAULT_PLOOMBER_CONF)
 
     def uid_default(self):
-        return str(uuid4())
+        config = self.load_config()
+        if config:
+            _uid = config.get("uid")
+            return _uid
+        else:
+            return str(uuid4())
 
     def is_first_time(self):
         config = self.load_config()

--- a/src/ploomber_core/telemetry/telemetry.py
+++ b/src/ploomber_core/telemetry/telemetry.py
@@ -85,6 +85,14 @@ class Internal(Config):
     def uid_default(self):
         return str(uuid4())
 
+    def is_first_time(self):
+        config = self.load_config()
+        if config:
+            first_time = config.get("first_time")
+            return first_time
+        else:
+            return True
+
 
 def python_version():
     py_version = sys.version_info
@@ -281,9 +289,9 @@ def check_first_time_usage():
     The function checks for first time usage if the conf file exists and the
     uid file doesn't exist.
     """
-    internal = Internal()
-    first_time = internal.first_time
-    internal.first_time = False
+    first_time = internal.is_first_time()
+    if first_time:
+        internal.first_time = False
     return first_time
 
 
@@ -337,7 +345,6 @@ def check_version(package_name, version):
     if not settings.version_check_enabled:
         return
 
-    internal = Internal()
     now = datetime.datetime.now()
 
     # Check if we already notified in the last 2 days
@@ -379,8 +386,6 @@ def _get_telemetry_info(package_name, version):
         # Check first time install
         is_install = check_first_time_usage()
 
-        # if not uid, create
-        internal = Internal()
         return telemetry_enabled, internal.uid, is_install
     else:
         return False, '', False
@@ -558,3 +563,6 @@ def get_sanitized_argv():
             return [bin] + sys.argv[1:]
         except Exception:
             return None
+
+
+internal = Internal()

--- a/tests/telemetry/test_telemetry.py
+++ b/tests/telemetry/test_telemetry.py
@@ -260,7 +260,9 @@ def test_os_type(monkeypatch, os_param):
     assert os_type == os_param
 
 
-def test_full_telemetry_info(ignore_env_var_and_set_tmp_default_home_dir):
+def test_full_telemetry_info(monkeypatch,
+                             ignore_env_var_and_set_tmp_default_home_dir):
+    monkeypatch.setattr(telemetry, "internal", telemetry.Internal())
     (stat_enabled, uid, is_install) = \
         telemetry._get_telemetry_info('ploomber', '0.14.0')
     assert stat_enabled is True
@@ -387,6 +389,8 @@ def test_version_skips_when_updated(tmp_directory, capsys, monkeypatch):
 
 
 def test_user_output_on_different_versions(tmp_directory, capsys, monkeypatch):
+    monkeypatch.setattr(telemetry, "internal", telemetry.Internal())
+
     mock_version = Mock()
     monkeypatch.setattr(telemetry, 'get_latest_version', mock_version)
     write_to_conf_file(tmp_directory=tmp_directory,
@@ -412,6 +416,7 @@ def test_no_output_latest_version(tmp_directory, capsys, monkeypatch):
 
 
 def test_output_on_date_diff(tmp_directory, capsys, monkeypatch):
+    monkeypatch.setattr(telemetry, "internal", telemetry.Internal())
     # Warning should be caught since the date and version are off
     mock_version = Mock()
     monkeypatch.setattr(telemetry, 'get_latest_version', mock_version)


### PR DESCRIPTION
## Changes
1. Moved the `internal` parameter to a global parameter to reduce the number of initializations when using Parallel executor
2. Checking if this is the 1st usage by reading directly from `uid.yaml`
3. Update `uid.yaml` file only if it's the 1st usage

Fixes: #19 

* I also changed the default value for the uuid by checking first if the file conf. file exist but I'm not sure this is needed. 