### PR TITLE
telemetry initialization wraped with try

### DIFF
--- a/src/ploomber_core/telemetry/telemetry.py
+++ b/src/ploomber_core/telemetry/telemetry.py
@@ -570,4 +570,7 @@ def get_sanitized_argv():
             return None
 
 
-internal = Internal()
+try:
+    internal = Internal()
+except Exception:
+    pass

--- a/src/ploomber_core/telemetry/telemetry.py
+++ b/src/ploomber_core/telemetry/telemetry.py
@@ -572,5 +572,5 @@ def get_sanitized_argv():
 
 try:
     internal = Internal()
-except Exception:
+except PermissionError:
     pass

--- a/tests/telemetry/test_telemetry.py
+++ b/tests/telemetry/test_telemetry.py
@@ -560,6 +560,7 @@ def test_log_call_add_payload_success(mock_telemetry):
 
 
 def test_permissions_error(monkeypatch):
+    monkeypatch.setattr(telemetry, 'DEFAULT_HOME_DIR', '.')
     stats = Path('stats')
 
     if os.path.exists(stats):
@@ -568,7 +569,6 @@ def test_permissions_error(monkeypatch):
 
     os.mkdir(stats)
     os.chmod(stats, stat.S_IRUSR)
-    monkeypatch.setattr(telemetry, 'DEFAULT_HOME_DIR', '.')
 
     statinfo = os.stat(stats)
 

--- a/tests/telemetry/test_telemetry.py
+++ b/tests/telemetry/test_telemetry.py
@@ -557,6 +557,15 @@ def test_log_call_add_payload_success(mock_telemetry):
     ])
 
 
+def test_permissions_error(tmp_directory, monkeypatch, capsys):
+    stats = Path('stats')
+    stats.mkdir(mode=444)
+    monkeypatch.setattr(telemetry, 'DEFAULT_HOME_DIR', '.')
+
+    with pytest.raises(PermissionError):
+        telemetry.Internal()
+
+
 @pytest.mark.allow_posthog
 def test_hides_posthog_log(caplog, monkeypatch):
 

--- a/tests/telemetry/test_telemetry.py
+++ b/tests/telemetry/test_telemetry.py
@@ -557,7 +557,7 @@ def test_log_call_add_payload_success(mock_telemetry):
     ])
 
 
-def test_permissions_error(tmp_directory, monkeypatch, capsys):
+def test_permissions_error(monkeypatch):
     stats = Path('stats')
     stats.mkdir(mode=444)
     monkeypatch.setattr(telemetry, 'DEFAULT_HOME_DIR', '.')

--- a/tests/telemetry/test_telemetry.py
+++ b/tests/telemetry/test_telemetry.py
@@ -559,17 +559,24 @@ def test_log_call_add_payload_success(mock_telemetry):
     ])
 
 
-def test_permissions_error(monkeypatch, capsys):
+def test_permissions_error(monkeypatch):
     stats = Path('stats')
+
     if os.path.exists(stats):
+        os.chmod(stats, 777)
         shutil.rmtree(stats)
 
     os.mkdir(stats)
     os.chmod(stats, stat.S_IRUSR)
     monkeypatch.setattr(telemetry, 'DEFAULT_HOME_DIR', '.')
 
-    with pytest.raises(PermissionError):
-        telemetry.Internal()
+    statinfo = os.stat(stats)
+
+    is_read_only = statinfo.st_mode == 16640
+
+    if is_read_only:
+        with pytest.raises(PermissionError):
+            telemetry.Internal()
 
 
 @pytest.mark.allow_posthog

--- a/tests/telemetry/test_telemetry.py
+++ b/tests/telemetry/test_telemetry.py
@@ -5,6 +5,8 @@ from pathlib import Path
 import datetime
 import logging
 import os
+import stat
+import shutil
 
 import pytest
 import yaml
@@ -557,9 +559,13 @@ def test_log_call_add_payload_success(mock_telemetry):
     ])
 
 
-def test_permissions_error(monkeypatch):
+def test_permissions_error(monkeypatch, capsys):
     stats = Path('stats')
-    stats.mkdir(mode=444)
+    if os.path.exists(stats):
+        shutil.rmtree(stats)
+
+    os.mkdir(stats)
+    os.chmod(stats, stat.S_IRUSR)
     monkeypatch.setattr(telemetry, 'DEFAULT_HOME_DIR', '.')
 
     with pytest.raises(PermissionError):


### PR DESCRIPTION
Fixes read-only error on AWS lambda APIHanlder by wrapping the initialization with try/except

the error
```
{
  "errorMessage": "[Errno 30] Read-only file system: '/home/sbx_user1051'",
  "errorType": "OSError",
  "requestId": "",
  "stackTrace": [
    "  File \"/var/lang/lib/python3.9/importlib/__init__.py\", line 127, in import_module\n    return _bootstrap._gcd_import(name[level:], package, level)\n",
    "  File \"<frozen importlib._bootstrap>\", line 1030, in _gcd_import\n",
    "  File \"<frozen importlib._bootstrap>\", line 1007, in _find_and_load\n",
    "  File \"<frozen importlib._bootstrap>\", line 986, in _find_and_load_unlocked\n",
    "  File \"<frozen importlib._bootstrap>\", line 680, in _load_unlocked\n",
    "  File \"<frozen importlib._bootstrap_external>\", line 850, in exec_module\n",
    "  File \"<frozen importlib._bootstrap>\", line 228, in _call_with_frames_removed\n",
    "  File \"/var/task/app.py\", line 8, in <module>\n    from ploombertools.execute import execute\n",
    "  File \"/var/task/ploombertools/execute/execute.py\", line 44, in <module>\n    import k2s\n",
    "  File \"/var/task/k2s/__init__.py\", line 1, in <module>\n    from k2s.parse import bootstrap_env\n",
    "  File \"/var/task/k2s/parse.py\", line 12, in <module>\n    from k2s.env import install\n",
    "  File \"/var/task/k2s/env.py\", line 4, in <module>\n    from k2s.conda import CondaManager\n",
    "  File \"/var/task/k2s/conda.py\", line 10, in <module>\n    from ploomber_core.telemetry.telemetry import Telemetry\n",
    "  File \"/var/task/ploomber_core/telemetry/telemetry.py\", line 573, in <module>\n    internal = Internal()\n",
    "  File \"/var/task/ploomber_core/config.py\", line 18, in __init__\n    self._init_values()\n",
    "  File \"/var/task/ploomber_core/config.py\", line 96, in _init_values\n    value = getattr(self, name)()\n",
    "  File \"/var/task/ploomber_core/telemetry/telemetry.py\", line 86, in uid_default\n    config = self.load_config()\n",
    "  File \"/var/task/ploomber_core/config.py\", line 117, in load_config\n    path = self.path()\n",
    "  File \"/var/task/ploomber_core/telemetry/telemetry.py\", line 83, in path\n    return Path(check_dir_exist(CONF_DIR), DEFAULT_PLOOMBER_CONF)\n",
    "  File \"/var/task/ploomber_core/telemetry/telemetry.py\", line 269, in check_dir_exist\n    p.mkdir(parents=True)\n",
    "  File \"/var/lang/lib/python3.9/pathlib.py\", line 1327, in mkdir\n    self.parent.mkdir(parents=True, exist_ok=True)\n",
    "  File \"/var/lang/lib/python3.9/pathlib.py\", line 1327, in mkdir\n    self.parent.mkdir(parents=True, exist_ok=True)\n",
    "  File \"/var/lang/lib/python3.9/pathlib.py\", line 1323, in mkdir\n    self._accessor.mkdir(self, mode)\n"
  ]
}
```