### PR TITLE
Update telemetry.py

### DIFF
--- a/src/ploomber_core/telemetry/telemetry.py
+++ b/src/ploomber_core/telemetry/telemetry.py
@@ -807,6 +807,7 @@ def _map_parameters_in_fn_call(args, kwargs, func):
 
 
 try:
-    internal = Internal()
+    # initialize config at import time to prevent race conditions
+    Internal()
 except Exception:
     pass


### PR DESCRIPTION
I think this wouldn't affect anything since the `internal` variable is not used. I think it's better since the old version would expose an `internal` variable (and this variable would not exist when the initialization fails). Also added a comment to explain why (I think) this line is there.