### PR TITLE
Enhance modify_exceptions func - Deduplicate community message & Add TypeError Support

### DIFF
--- a/src/ploomber_core/exceptions.py
+++ b/src/ploomber_core/exceptions.py
@@ -5,6 +5,15 @@ from gettext import gettext as _
 from click.exceptions import ClickException
 from click._compat import get_text_stderr
 from click.utils import echo
+COMMUNITY_LINK = "https://ploomber.io/community"
+
+COMMUNITY = (
+    "\nIf you need help solving this "
+    "issue, send us a message: " + COMMUNITY_LINK
+)
+
+def get_community_link():
+    return COMMUNITY_LINK
 
 
 def _format_message(exception):
@@ -43,13 +52,6 @@ class BaseException(ClickException):
 
         echo(_(self.get_message()), file=file)
 
-
-COMMUNITY = (
-    "\nIf you need help solving this "
-    "issue, send us a message: https://ploomber.io/community"
-)
-
-
 class PloomberValueError(ValueError):
     """Subclass of ValueError that displays the community link"""
 
@@ -83,9 +85,10 @@ def modify_exceptions(fn):
     def wrapper(*args, **kwargs):
         try:
             return fn(*args, **kwargs)
-        except ValueError as e:
-            message = e.args[0] + COMMUNITY
-            e.args = (message,)
+        except (ValueError, TypeError) as e:
+            if COMMUNITY not in e.args[0]:
+                message = e.args[0] + COMMUNITY
+                e.args = (message,)
             raise
 
     return wrapper

--- a/src/ploomber_core/exceptions.py
+++ b/src/ploomber_core/exceptions.py
@@ -5,12 +5,13 @@ from gettext import gettext as _
 from click.exceptions import ClickException
 from click._compat import get_text_stderr
 from click.utils import echo
+
 COMMUNITY_LINK = "https://ploomber.io/community"
 
 COMMUNITY = (
-    "\nIf you need help solving this "
-    "issue, send us a message: " + COMMUNITY_LINK
+    "\nIf you need help solving this " "issue, send us a message: " + COMMUNITY_LINK
 )
+
 
 def get_community_link():
     return COMMUNITY_LINK
@@ -51,6 +52,7 @@ class BaseException(ClickException):
             file = get_text_stderr()
 
         echo(_(self.get_message()), file=file)
+
 
 class PloomberValueError(ValueError):
     """Subclass of ValueError that displays the community link"""

--- a/src/ploomber_core/telemetry/telemetry.py
+++ b/src/ploomber_core/telemetry/telemetry.py
@@ -686,7 +686,6 @@ class Telemetry:
                     else:
                         result = func(*args, **kwargs)
                 except Exception as e:
-
                     metadata_error = {
                         # can we log None to posthog?
                         "type": getattr(e, "type_", None),

--- a/tests/telemetry/test_telemetry.py
+++ b/tests/telemetry/test_telemetry.py
@@ -184,7 +184,6 @@ def test_env_var_takes_precedence(
     env_value,
     expected_second,
 ):
-
     stats = Path("stats")
     stats.mkdir()
 

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -48,7 +48,7 @@ def test_modify_exceptions_value_error():
     with pytest.raises(ValueError) as excinfo:
         crash()
 
-    assert "https://ploomber.io/community" in str(excinfo.value)
+    assert exceptions.get_community_link() in str(excinfo.value)
 
 
 def test_modify_exceptions_value_error_method():
@@ -60,7 +60,7 @@ def test_modify_exceptions_value_error_method():
     with pytest.raises(ValueError) as excinfo:
         Something().crash()
 
-    assert "https://ploomber.io/community" in str(excinfo.value)
+    assert exceptions.get_community_link() in str(excinfo.value)
 
 
 def test_do_not_catch_other_errors():
@@ -71,4 +71,22 @@ def test_do_not_catch_other_errors():
     with pytest.raises(TypeError) as excinfo:
         crash()
 
-    assert "https://ploomber.io/community" not in str(excinfo.value)
+    assert exceptions.get_community_link() in str(excinfo.value)
+
+def test_modify_exceptions_duplicated_community_messages():
+    @exceptions.modify_exceptions
+    def parent():
+        child()
+
+    @exceptions.modify_exceptions
+    def child():
+        grand_child()
+
+    @exceptions.modify_exceptions
+    def grand_child():
+        raise ValueError("message from grand_child")
+
+    with pytest.raises(ValueError) as excinfo:
+        parent()
+
+    assert str(excinfo.value).count(exceptions.get_community_link()) == 1

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -97,7 +97,7 @@ def test_do_not_catch_other_errors():
     assert exceptions.get_community_link() not in str(excinfo.value)
 
 
-def test_modify_exceptions_duplicated_community_messages():
+def test_modify_exceptions_deduplicated_community_messages():
     @exceptions.modify_exceptions
     def parent():
         child()

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -62,6 +62,7 @@ def test_modify_exceptions_value_error_method():
 
     assert exceptions.get_community_link() in str(excinfo.value)
 
+
 def test_modify_exceptions_type_error():
     @exceptions.modify_exceptions
     def crash():
@@ -84,6 +85,7 @@ def test_modify_exceptions_type_error_method():
 
     assert exceptions.get_community_link() in str(excinfo.value)
 
+
 def test_do_not_catch_other_errors():
     @exceptions.modify_exceptions
     def crash():
@@ -93,6 +95,7 @@ def test_do_not_catch_other_errors():
         crash()
 
     assert exceptions.get_community_link() not in str(excinfo.value)
+
 
 def test_modify_exceptions_duplicated_community_messages():
     @exceptions.modify_exceptions

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -113,4 +113,5 @@ def test_modify_exceptions_duplicated_community_messages():
     with pytest.raises(ValueError) as excinfo:
         parent()
 
+    # Make sure the community link only appears once
     assert str(excinfo.value).count(exceptions.get_community_link()) == 1

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -62,8 +62,7 @@ def test_modify_exceptions_value_error_method():
 
     assert exceptions.get_community_link() in str(excinfo.value)
 
-
-def test_do_not_catch_other_errors():
+def test_modify_exceptions_type_error():
     @exceptions.modify_exceptions
     def crash():
         raise TypeError("some message")
@@ -72,6 +71,28 @@ def test_do_not_catch_other_errors():
         crash()
 
     assert exceptions.get_community_link() in str(excinfo.value)
+
+
+def test_modify_exceptions_type_error_method():
+    class Something:
+        @exceptions.modify_exceptions
+        def crash(self):
+            raise TypeError("some message")
+
+    with pytest.raises(TypeError) as excinfo:
+        Something().crash()
+
+    assert exceptions.get_community_link() in str(excinfo.value)
+
+def test_do_not_catch_other_errors():
+    @exceptions.modify_exceptions
+    def crash():
+        raise IndexError("some message")
+
+    with pytest.raises(IndexError) as excinfo:
+        crash()
+
+    assert exceptions.get_community_link() not in str(excinfo.value)
 
 def test_modify_exceptions_duplicated_community_messages():
     @exceptions.modify_exceptions


### PR DESCRIPTION
## Changes

In response of https://github.com/ploomber/core/issues/41

- Add TypeError support in `modify_exceptions` & test cases
- Fix Deduplicated community message issue in `modify_exceptions` & test case

## Snapshot for the error message

Before the deduplication (Manually print from [a test case](https://github.com/ploomber/core/pull/42/files#diff-f46006e3f43ffb1dd5d6862005427f6620f4dcfb1fa2f883d8482550069eeeccR100)):
<img width="643" alt="Screenshot 2023-02-01 at 12 18 08 PM" src="https://user-images.githubusercontent.com/123580782/216115526-8b284ca9-d6b2-4d8c-be4d-204288564add.png">

After:
<img width="619" alt="Screenshot 2023-02-01 at 12 17 22 PM" src="https://user-images.githubusercontent.com/123580782/216115640-9c42e61a-c820-418d-b4ff-12d1d1ab855e.png">

<!-- readthedocs-preview ploomber-core start -->
----
:books: Documentation preview :books:: https://ploomber-core--42.org.readthedocs.build/en/42/

<!-- readthedocs-preview ploomber-core end -->