### PR TITLE
improving unit testing for functions decorated with log_call

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,9 +34,13 @@ jobs:
           pip install ".[dev]"
 
 
-      - name: Test with pytest
+      - name: Doctests
         run: |
           pytest src --doctest-modules
+
+
+      - name: Unit tests
+        run: |
           pytest --durations-min=5
 
 

--- a/doc/telemetry.md
+++ b/doc/telemetry.md
@@ -73,23 +73,31 @@ For more details, see the [API Reference](api/telemetry).
 
 +++
 
-To unit test decorated functions, check the `._telemetry` attribute. If it exists, it means the function has been decorated with `@log_call()`, and it'll contain the arguments passed and the action name:
+To unit test decorated functions, call the function and check `__wrapped__._telemetry_started` attribute. If it exists, it means the function has been decorated with `@log_call()`, you can use it to verify what's logged:
 
 ```{code-cell} ipython3
-assert add._telemetry == {'action': 'ploomber-core-add',
- 'payload': False,
- 'log_args': False,
- 'ignore_args': set(),
- 'group': None}
+@telemetry.log_call(log_args=True, ignore_args=("y",))
+def divide(x, y):
+    return x / y
+
+_ = divide(2, 4)
 ```
 
 ```{code-cell} ipython3
-assert obj.add._telemetry == {'action': 'ploomber-core-add',
- 'payload': False,
- 'log_args': False,
- 'ignore_args': set(),
- 'group': None}
+from unittest.mock import ANY
+
+assert divide.__wrapped__._telemetry_started == {
+    "action": "ploomber-core-divide-started",
+    "metadata": {
+        "argv": ANY,
+        "args": {"x": 2},
+    },
+}
 ```
+
+`__wrapped__._telemetry_started` will keep the latest logged data, so you must call it at least one; otherwise, it'll be `None`.
+
++++
 
 ## Configuring telemetry in a package
 

--- a/doc/telemetry.md
+++ b/doc/telemetry.md
@@ -21,7 +21,6 @@ Set the `_PLOOMBER_TELEMETRY_DEBUG` environment variable (any value) to override
 
 `ploomber-core` implements a `Telemetry` class that we use to understand usage and improve our products:
 
-
 ```{code-cell} ipython3
 from ploomber_core.telemetry import Telemetry
 ```
@@ -50,11 +49,47 @@ def add(x, y):
 add(1, 41)
 ```
 
+Log method calls:
+
+```{code-cell} ipython3
+class MyClass:
+    @telemetry.log_call()
+    def add(self, x, y):
+        return x, y
+
+obj = MyClass()
+obj.add(x=1, y=2)
+```
+
 ```{note}
 Event names are normalized by replacing underscores (`_`) with hyphens (`-`).
 ```
 
-For more details, see the [API Reference](api).
+For more details, see the [API Reference](api/telemetry).
+
++++
+
+## Unit testing
+
++++
+
+To unit test decorated functions, check the `._telemetry` attribute. If it exists, it means the function has been decorated with `@log_call()`, and it'll contain the arguments passed and the action name:
+
+```{code-cell} ipython3
+assert add._telemetry == {'action': 'ploomber-core-add',
+ 'payload': False,
+ 'log_args': False,
+ 'ignore_args': set(),
+ 'group': None}
+```
+
+```{code-cell} ipython3
+assert obj.add._telemetry == {'action': 'ploomber-core-add',
+ 'payload': False,
+ 'log_args': False,
+ 'ignore_args': set(),
+ 'group': None}
+```
 
 ## Configuring telemetry in a package
 

--- a/src/ploomber_core/telemetry/telemetry.py
+++ b/src/ploomber_core/telemetry/telemetry.py
@@ -659,7 +659,22 @@ class Telemetry:
         3
 
 
+        Unit testing (check the ``_telemetry`` attribute):
 
+        >>> from ploomber_core.telemetry import Telemetry
+        >>> telemetry = Telemetry("APIKEY", "packagename", "0.1")
+        >>> @telemetry.log_call()
+        ... def add(x, y):
+        ...     return x + y
+        >>> add._telemetry["action"]
+        'packagename-add'
+        >>> add._telemetry["payload"]
+        False
+        >>> add._telemetry["log_args"]
+        False
+        >>> add._telemetry["ignore_args"]
+        set()
+        >>> add._telemetry["group"]
         """
 
         if ignore_args is None:
@@ -684,7 +699,7 @@ class Telemetry:
                 payload=payload,
                 log_args=log_args,
                 ignore_args=ignore_args,
-                group=ignore_args,
+                group=group,
             )
 
             @wraps(func)

--- a/src/ploomber_core/telemetry/telemetry.py
+++ b/src/ploomber_core/telemetry/telemetry.py
@@ -669,17 +669,26 @@ class Telemetry:
 
         def _log_call(func):
             is_method = is_first_arg_self(func)
+            # determine action name
+            action_ = self.package_name
+
+            if group:
+                action_ = f"{action_}-{group}"
+
+            name = action or getattr(func, "__name__", "funcion-without-name")
+            action_ = (f"{action_}-{name}").replace("_", "-")
+
+            # store data for unit testing decorated functions
+            func._telemetry = dict(
+                action=action_,
+                payload=payload,
+                log_args=log_args,
+                ignore_args=ignore_args,
+                group=ignore_args,
+            )
 
             @wraps(func)
             def wrapper(*args, **kwargs):
-                action_ = self.package_name
-
-                if group:
-                    action_ = f"{action_}-{group}"
-
-                name = action or getattr(func, "__name__", "funcion-without-name")
-                action_ = (f"{action_}-{name}").replace("_", "-")
-
                 if log_args:
                     args_parsed = _get_args(func, args, kwargs, ignore_args)
                 else:

--- a/src/ploomber_core/telemetry/telemetry.py
+++ b/src/ploomber_core/telemetry/telemetry.py
@@ -37,7 +37,6 @@ import json
 import os
 from pathlib import Path
 import sys
-import inspect
 from uuid import uuid4
 from functools import wraps
 import platform

--- a/tests/telemetry/test_telemetry.py
+++ b/tests/telemetry/test_telemetry.py
@@ -1108,13 +1108,19 @@ def test_exposes_telemetry_data_for_testing_params():
 
     assert my_function.__wrapped__._telemetry_started == {
         "action": "some-package-my-function-started",
-        "metadata": {"argv": ANY, "args": {"x": 1, "y": 2},},
+        "metadata": {
+            "argv": ANY,
+            "args": {"x": 1, "y": 2},
+        },
     }
 
     assert my_function.__wrapped__._telemetry_success == {
         "action": "some-package-my-function-success",
         "total_runtime": ANY,
-        "metadata": {"argv": ANY, "args": {"x": 1, "y": 2},},
+        "metadata": {
+            "argv": ANY,
+            "args": {"x": 1, "y": 2},
+        },
     }
 
     assert my_function.__wrapped__._telemetry_error is None

--- a/tests/telemetry/test_telemetry.py
+++ b/tests/telemetry/test_telemetry.py
@@ -1006,3 +1006,19 @@ def test_log_call_stored_values(monkeypatch):
 def test_get_sanitized_sys_argv(argv, expected, monkeypatch):
     monkeypatch.setattr(telemetry.sys, "argv", argv)
     assert telemetry.get_sanitized_argv() == expected
+
+
+def test_exposes_data_for_testing():
+    my_telemetry = telemetry.Telemetry(MOCK_API_KEY, "some-package", "1.2.2")
+
+    @my_telemetry.log_call()
+    def my_function():
+        pass
+
+    assert my_function._telemetry == {
+        "group": set(),
+        "ignore_args": set(),
+        "log_args": False,
+        "payload": False,
+        "action": "some-package-my-function",
+    }

--- a/tests/telemetry/test_telemetry.py
+++ b/tests/telemetry/test_telemetry.py
@@ -1016,7 +1016,7 @@ def test_exposes_data_for_testing():
         pass
 
     assert my_function._telemetry == {
-        "group": set(),
+        "group": None,
         "ignore_args": set(),
         "log_args": False,
         "payload": False,


### PR DESCRIPTION
currently, when writing unit tests for functions decorated with `log_call`; we have to write logic to mock the posthog module so we capture the calls. this is a leaky abstraction since the contributor needs to know the details of the telemetry module implementation.

A better solution is to expose an API that allows contributors to check whether their functions will be logged correctly. This PR adds a `_telemetry` attribute to decorated functions which can be easily tested.

closes #37
closes #36


moving forward, this is how we should write unit tests for logged functions. [here's an example](https://ploomber-core--46.org.readthedocs.build/en/46/telemetry.html#unit-testing)

<!-- readthedocs-preview ploomber-core start -->
----
:books: Documentation preview :books:: https://ploomber-core--46.org.readthedocs.build/en/46/

<!-- readthedocs-preview ploomber-core end -->