### PR TITLE
note for tutorial dependencies

### DIFF
--- a/doc/dependencies.md
+++ b/doc/dependencies.md
@@ -43,8 +43,7 @@ some_optional_functionality()
 ```{eval-rst}
 .. note::
 
-   We should use the `@requires` decorator only when certain parts of the project require extra packages. If the extra package is required in a tutorial then we can either
-   mention the installation step in the tutorial itself, or add it to the document specific dependencies if necessary.
+   We should only use the `@requires` decorator when certain parts of the project require extra packages. If the extra package is only required in a tutorial then we should include it in the installation step in the tutorial itself,
 ```
 
 

--- a/doc/dependencies.md
+++ b/doc/dependencies.md
@@ -20,7 +20,7 @@ Often our packages contain features that require extra packages. If a feature is
 
 ## Example
 
-Decorate a function witht `@requires` and pass a list of the packages.
+Decorate a function with `@requires` and pass a list of the packages.
 
 ```{code-cell} ipython3
 from ploomber_core.dependencies import requires
@@ -39,6 +39,14 @@ Since `some_package` is not installed, calling the function raises an error (the
 
 some_optional_functionality()
 ```
+
+```{eval-rst}
+.. note::
+
+   We should use the `@requires` decorator only when certain parts of the project require extra packages. If the extra package is required in a tutorial then we can either
+   mention the installation step in the tutorial itself, or add it to the document specific dependencies if necessary.
+```
+
 
 ## Customizing the error message
 


### PR DESCRIPTION
Add note for tutorial dependencies : This had come up during our discussion on Neural Network tracking dependencies.

<!-- readthedocs-preview ploomber-core start -->
----
:books: Documentation preview :books:: https://ploomber-core--49.org.readthedocs.build/en/49/

<!-- readthedocs-preview ploomber-core end -->