### PR TITLE
fix check_installed

### DIFF
--- a/src/ploomber_core/dependencies.py
+++ b/src/ploomber_core/dependencies.py
@@ -27,7 +27,6 @@ def requires(pkgs, name=None, extra_msg=None, pip_names=None):
         command, use it if different to the package name itself
 
     """
-    pkgs = [pkg.replace("-", "_") for pkg in pkgs]
 
     def decorator(f):
         @wraps(f)
@@ -70,6 +69,8 @@ def check_installed(pkgs, name, extra_msg=None, pip_names=None):
         command, use it if different to the package name itself
 
     """
+    pkgs = [pkg.replace("-", "_") for pkg in pkgs]
+
     is_pkg_missing = [importlib.util.find_spec(pkg) is None for pkg in pkgs]
 
     if any(is_pkg_missing):

--- a/tests/test_dependencies.py
+++ b/tests/test_dependencies.py
@@ -48,6 +48,14 @@ from ploomber_core.dependencies import requires, check_installed
             dict(pkgs=["ploomber-core", "p1"]),
             "'p1' is required to use 'fn'. Install with: pip install 'p1'",
         ],
+        [
+            # test missing packages with - and hyphens
+            dict(pkgs=["pkg-a", "pkg-b"]),
+            (
+                "'pkg_a' 'pkg_b' are required to use 'fn'. "
+                "Install with: pip install 'pkg_a' 'pkg_b'"
+            ),
+        ],
     ],
 )
 def test_requires(params, expected):
@@ -85,6 +93,14 @@ def test_requires(params, expected):
         [
             dict(pkgs=["p1"], pip_names=["n1"]),
             "'n1' is required to use 'fn'. Install with: pip install 'n1'",
+        ],
+        [
+            # test missing packages with - and hyphens
+            dict(pkgs=["pkg-a", "pkg-b"]),
+            (
+                "'pkg_a' 'pkg_b' are required to use 'fn'. "
+                "Install with: pip install 'pkg_a' 'pkg_b'"
+            ),
         ],
     ],
 )


### PR DESCRIPTION
closes #60

fixing check_installed so it behaves the same as `@requires`

<!-- readthedocs-preview ploomber-core start -->
----
:books: Documentation preview :books:: https://ploomber-core--61.org.readthedocs.build/en/61/

<!-- readthedocs-preview ploomber-core end -->