### PR TITLE
removes start event from telemetry

### DIFF
--- a/doc/_config.yml
+++ b/doc/_config.yml
@@ -32,3 +32,5 @@ sphinx:
   extra_extensions:
     - 'sphinx.ext.autodoc'
     - 'sphinx.ext.napoleon'
+  config:
+    nb_execution_show_tb: True

--- a/doc/telemetry.md
+++ b/doc/telemetry.md
@@ -90,7 +90,8 @@ _ = divide(2, 4)
 from unittest.mock import ANY
 
 assert divide.__wrapped__._telemetry_success == {
-    "action": "ploomber-core-divide-started",
+    "action": "ploomber-core-divide-success",
+    "total_runtime": ANY,
     "metadata": {
         "argv": ANY,
         "args": {"x": 2},

--- a/doc/telemetry.md
+++ b/doc/telemetry.md
@@ -75,7 +75,7 @@ For more details, see the [API Reference](api/telemetry).
 
 +++
 
-To unit test decorated functions, call the function and check `__wrapped__._telemetry_started` attribute. If it exists, it means the function has been decorated with `@log_call()`, you can use it to verify what's logged:
+To unit test decorated functions, call the function and check `__wrapped__._telemetry_success` attribute. If it exists, it means the function has been decorated with `@log_call()`, you can use it to verify what's logged:
 
 ```{code-cell} ipython3
 @telemetry.log_call(log_args=True, ignore_args=("y",))
@@ -89,7 +89,7 @@ _ = divide(2, 4)
 ```{code-cell} ipython3
 from unittest.mock import ANY
 
-assert divide.__wrapped__._telemetry_started == {
+assert divide.__wrapped__._telemetry_success == {
     "action": "ploomber-core-divide-started",
     "metadata": {
         "argv": ANY,
@@ -98,7 +98,7 @@ assert divide.__wrapped__._telemetry_started == {
 }
 ```
 
-`__wrapped__._telemetry_started` will keep the latest logged data, so you must call it at least one; otherwise, it'll be `None`.
+`__wrapped__._telemetry_success` will keep the latest logged data, so you must call it at least one; otherwise, it'll be `None`.
 
 +++
 

--- a/src/ploomber_core/telemetry/telemetry.py
+++ b/src/ploomber_core/telemetry/telemetry.py
@@ -594,7 +594,6 @@ class Telemetry:
             name = action or getattr(func, "__name__", "funcion-without-name")
             action_ = (f"{action_}-{name}").replace("_", "-")
 
-            func._telemetry_started = None
             func._telemetry_success = None
             func._telemetry_error = None
 
@@ -610,7 +609,6 @@ class Telemetry:
             @wraps(func)
             def wrapper(*args, **kwargs):
                 # reset attributes before calling
-                func._telemetry_started = None
                 func._telemetry_success = None
                 func._telemetry_error = None
 
@@ -625,10 +623,6 @@ class Telemetry:
 
                 if log_args:
                     metadata_started["args"] = args_parsed
-
-                started = dict(action=f"{action_}-started", metadata=metadata_started)
-                func._telemetry_started = started
-                self.log_api(**started)
 
                 start = datetime.datetime.now()
 

--- a/tests/telemetry/test_telemetry.py
+++ b/tests/telemetry/test_telemetry.py
@@ -465,10 +465,6 @@ def test_log_call_success(mock_telemetry):
     mock_telemetry.assert_has_calls(
         [
             call(
-                action="some-package-some-action-started",
-                metadata=dict(argv=["bin", "arg"]),
-            ),
-            call(
                 action="some-package-some-action-success",
                 total_runtime="1",
                 metadata=dict(argv=["bin", "arg"]),
@@ -489,10 +485,6 @@ def test_log_call_exception(mock_telemetry):
 
     mock_telemetry.assert_has_calls(
         [
-            call(
-                action="some-package-some-action-started",
-                metadata=dict(argv=["bin", "arg"]),
-            ),
             call(
                 action="some-package-some-action-error",
                 total_runtime="1",
@@ -518,10 +510,6 @@ def test_log_call_logs_type(mock_telemetry):
 
     mock_telemetry.assert_has_calls(
         [
-            call(
-                action="some-package-some-action-started",
-                metadata=dict(argv=["bin", "arg"]),
-            ),
             call(
                 action="some-package-some-action-error",
                 total_runtime="1",
@@ -549,10 +537,6 @@ def test_log_call_add_payload_error(mock_telemetry):
     mock_telemetry.assert_has_calls(
         [
             call(
-                action="some-package-some-action-started",
-                metadata=dict(argv=["bin", "arg"]),
-            ),
-            call(
                 action="some-package-some-action-error",
                 total_runtime="1",
                 metadata={
@@ -577,10 +561,6 @@ def test_log_call_add_payload_success(mock_telemetry):
 
     mock_telemetry.assert_has_calls(
         [
-            call(
-                action="some-package-some-action-started",
-                metadata=dict(argv=["bin", "arg"]),
-            ),
             call(
                 action="some-package-some-action-success",
                 total_runtime="1",
@@ -607,10 +587,6 @@ def test_log_call_method_with_payload_success(mock_telemetry):
     mock_telemetry.assert_has_calls(
         [
             call(
-                action="some-package-TestClass-some-action-started",
-                metadata=dict(argv=["bin", "arg"]),
-            ),
-            call(
                 action="some-package-TestClass-some-action-success",
                 total_runtime="1",
                 metadata={"argv": ["bin", "arg"], "sum": 3},
@@ -636,10 +612,6 @@ def test_log_call_no_args_method_with_payload_success(mock_telemetry):
     mock_telemetry.assert_has_calls(
         [
             call(
-                action="some-package-TestClass-some-action-started",
-                metadata=dict(argv=["bin", "arg"]),
-            ),
-            call(
                 action="some-package-TestClass-some-action-success",
                 total_runtime="1",
                 metadata={"argv": ["bin", "arg"], "log": "some result"},
@@ -664,10 +636,6 @@ def test_log_call_keyword_args_method_with_payload_success(mock_telemetry):
     assert result == "Give me 5 apples and 10 bananas please"
     mock_telemetry.assert_has_calls(
         [
-            call(
-                action="some-package-TestClass-some-action-started",
-                metadata=dict(argv=["bin", "arg"]),
-            ),
             call(
                 action="some-package-TestClass-some-action-success",
                 total_runtime="1",
@@ -699,10 +667,6 @@ def test_log_call_keyword_only_args_method_with_payload_success(mock_telemetry):
     mock_telemetry.assert_has_calls(
         [
             call(
-                action="some-package-TestClass-some-action-started",
-                metadata=dict(argv=["bin", "arg"]),
-            ),
-            call(
                 action="some-package-TestClass-some-action-success",
                 total_runtime="1",
                 metadata={"argv": ["bin", "arg"], "log": ["jhonny", "mr_smith"]},
@@ -730,10 +694,6 @@ def test_log_call_keyword_only_positional_args_method_with_payload_success(
 
     mock_telemetry.assert_has_calls(
         [
-            call(
-                action="some-package-TestClass-some-action-started",
-                metadata=dict(argv=["bin", "arg"]),
-            ),
             call(
                 action="some-package-TestClass-some-action-success",
                 total_runtime="1",
@@ -763,10 +723,6 @@ def test_log_call_double_asterisk_args_method_with_payload_success(mock_telemetr
     mock_telemetry.assert_has_calls(
         [
             call(
-                action="some-package-TestClass-some-action-started",
-                metadata=dict(argv=["bin", "arg"]),
-            ),
-            call(
                 action="some-package-TestClass-some-action-success",
                 total_runtime="1",
                 metadata={"argv": ["bin", "arg"], "log": "name: Eric\nage: 19\n"},
@@ -792,10 +748,6 @@ def test_log_call_single_asterisk_args_method_with_payload_success(mock_telemetr
 
     mock_telemetry.assert_has_calls(
         [
-            call(
-                action="some-package-TestClass-some-action-started",
-                metadata=dict(argv=["bin", "arg"]),
-            ),
             call(
                 action="some-package-TestClass-some-action-success",
                 total_runtime="1",
@@ -907,27 +859,6 @@ def test_log_call_stored_values(monkeypatch):
     assert mock.call_args_list == [
         call(
             distinct_id="fake-uuid",
-            event="some-package-some-action-started",
-            properties={
-                "event_id": ANY,
-                "user_id": "fake-uuid",
-                "action": "some-package-some-action-started",
-                "client_time": ANY,
-                "metadata": {"argv": ["bin", "arg2", "arg2"]},
-                "total_runtime": None,
-                "python_version": py_version,
-                "version": "1.2.2",
-                "package_name": "some-package",
-                "docker_container": ANY,
-                "cloud": ANY,
-                "email": None,
-                "os": ANY,
-                "environment": ANY,
-                "telemetry_version": ANY,
-            },
-        ),
-        call(
-            distinct_id="fake-uuid",
             event="some-package-some-action-success",
             properties={
                 "event_id": ANY,
@@ -984,16 +915,10 @@ def test_exposes_telemetry_data_for_testing():
         "action": "some-package-my-function",
     }
 
-    assert my_function.__wrapped__._telemetry_started is None
     assert my_function.__wrapped__._telemetry_success is None
     assert my_function.__wrapped__._telemetry_error is None
 
     my_function()
-
-    assert my_function.__wrapped__._telemetry_started == {
-        "action": "some-package-my-function-started",
-        "metadata": {"argv": ANY},
-    }
 
     assert my_function.__wrapped__._telemetry_success == {
         "action": "some-package-my-function-success",
@@ -1019,7 +944,6 @@ def test_exposes_telemetry_data_for_testing_error():
         "action": "some-package-my-function",
     }
 
-    assert my_function.__wrapped__._telemetry_started is None
     assert my_function.__wrapped__._telemetry_success is None
     assert my_function.__wrapped__._telemetry_error is None
 
@@ -1027,11 +951,6 @@ def test_exposes_telemetry_data_for_testing_error():
         my_function()
     except ValueError:
         pass
-
-    assert my_function.__wrapped__._telemetry_started == {
-        "action": "some-package-my-function-started",
-        "metadata": {"argv": ANY},
-    }
 
     assert my_function.__wrapped__._telemetry_success is None
 
@@ -1061,19 +980,10 @@ def test_exposes_telemetry_data_for_testing_params():
         "group": None,
     }
 
-    assert my_function.__wrapped__._telemetry_started is None
     assert my_function.__wrapped__._telemetry_success is None
     assert my_function.__wrapped__._telemetry_error is None
 
     my_function(1, 2, 3)
-
-    assert my_function.__wrapped__._telemetry_started == {
-        "action": "some-package-my-function-started",
-        "metadata": {
-            "argv": ANY,
-            "args": {"x": 1, "y": 2},
-        },
-    }
 
     assert my_function.__wrapped__._telemetry_success == {
         "action": "some-package-my-function-success",

--- a/tests/telemetry/test_telemetry_log_args.py
+++ b/tests/telemetry/test_telemetry_log_args.py
@@ -38,32 +38,7 @@ def test_logs_args(mock_posthog, y, y_logged):
 
     add(x=1, y=y)
 
-    expected_first = dict(
-        distinct_id="UUID",
-        event="somepackage-add-started",
-        properties={
-            "event_id": ANY,
-            "user_id": "UUID",
-            "action": "somepackage-add-started",
-            "client_time": ANY,
-            "metadata": {
-                "args": {"x": 1, "y": y_logged},
-                "argv": ANY,
-            },
-            "total_runtime": None,
-            "python_version": ANY,
-            "version": "0.1",
-            "package_name": "somepackage",
-            "docker_container": False,
-            "cloud": None,
-            "email": None,
-            "os": ANY,
-            "environment": ANY,
-            "telemetry_version": ANY,
-        },
-    )
-
-    expected_second = dict(
+    expected = dict(
         distinct_id="UUID",
         event="somepackage-add-success",
         properties={
@@ -88,8 +63,7 @@ def test_logs_args(mock_posthog, y, y_logged):
         },
     )
 
-    assert mock_posthog.call_args_list[0][1] == expected_first
-    assert mock_posthog.call_args_list[1][1] == expected_second
+    assert mock_posthog.call_args_list[0][1] == expected
 
 
 @pytest.mark.parametrize(
@@ -117,32 +91,7 @@ def test_logs_args_with_group(mock_posthog, y, y_logged):
     obj = SomeObject()
     obj.add(x=1, y=y)
 
-    expected_first = dict(
-        distinct_id="UUID",
-        event="somepackage-SomeObject-add-started",
-        properties={
-            "event_id": ANY,
-            "user_id": "UUID",
-            "action": "somepackage-SomeObject-add-started",
-            "client_time": ANY,
-            "metadata": {
-                "args": {"x": 1, "y": y_logged},
-                "argv": ANY,
-            },
-            "total_runtime": None,
-            "python_version": ANY,
-            "version": "0.1",
-            "package_name": "somepackage",
-            "docker_container": False,
-            "cloud": None,
-            "email": None,
-            "os": ANY,
-            "environment": ANY,
-            "telemetry_version": ANY,
-        },
-    )
-
-    expected_second = dict(
+    expected = dict(
         distinct_id="UUID",
         event="somepackage-SomeObject-add-success",
         properties={
@@ -167,8 +116,7 @@ def test_logs_args_with_group(mock_posthog, y, y_logged):
         },
     )
 
-    assert mock_posthog.call_args_list[0][1] == expected_first
-    assert mock_posthog.call_args_list[1][1] == expected_second
+    assert mock_posthog.call_args_list[0][1] == expected
 
 
 def test_doesnt_log_args_with_disallowed_types(mock_posthog):
@@ -182,32 +130,7 @@ def test_doesnt_log_args_with_disallowed_types(mock_posthog):
 
     add(x=dict(a=1))
 
-    expected_first = dict(
-        distinct_id="UUID",
-        event="somepackage-add-started",
-        properties={
-            "event_id": ANY,
-            "user_id": "UUID",
-            "action": "somepackage-add-started",
-            "client_time": ANY,
-            "metadata": {
-                "args": {"y": 1},
-                "argv": ANY,
-            },
-            "total_runtime": None,
-            "python_version": ANY,
-            "version": "0.1",
-            "package_name": "somepackage",
-            "docker_container": False,
-            "cloud": None,
-            "email": None,
-            "os": ANY,
-            "environment": ANY,
-            "telemetry_version": ANY,
-        },
-    )
-
-    expected_second = dict(
+    expected = dict(
         distinct_id="UUID",
         event="somepackage-add-success",
         properties={
@@ -232,8 +155,7 @@ def test_doesnt_log_args_with_disallowed_types(mock_posthog):
         },
     )
 
-    assert mock_posthog.call_args_list[0][1] == expected_first
-    assert mock_posthog.call_args_list[1][1] == expected_second
+    assert mock_posthog.call_args_list[0][1] == expected
 
 
 def test_doesnt_log_ignored_args(mock_posthog):
@@ -247,32 +169,7 @@ def test_doesnt_log_ignored_args(mock_posthog):
 
     add(x=1)
 
-    expected_first = dict(
-        distinct_id="UUID",
-        event="somepackage-add-started",
-        properties={
-            "event_id": ANY,
-            "user_id": "UUID",
-            "action": "somepackage-add-started",
-            "client_time": ANY,
-            "metadata": {
-                "args": {"x": 1},
-                "argv": ANY,
-            },
-            "total_runtime": None,
-            "python_version": ANY,
-            "version": "0.1",
-            "package_name": "somepackage",
-            "docker_container": False,
-            "cloud": None,
-            "email": None,
-            "os": ANY,
-            "environment": ANY,
-            "telemetry_version": ANY,
-        },
-    )
-
-    expected_second = dict(
+    expected = dict(
         distinct_id="UUID",
         event="somepackage-add-success",
         properties={
@@ -297,8 +194,7 @@ def test_doesnt_log_ignored_args(mock_posthog):
         },
     )
 
-    assert mock_posthog.call_args_list[0][1] == expected_first
-    assert mock_posthog.call_args_list[1][1] == expected_second
+    assert mock_posthog.call_args_list[0][1] == expected
 
 
 def test_logs_if_error(mock_posthog):
@@ -312,31 +208,6 @@ def test_logs_if_error(mock_posthog):
 
     with pytest.raises(ValueError):
         add(x=1)
-
-    expected_first = dict(
-        distinct_id="UUID",
-        event="somepackage-add-started",
-        properties={
-            "event_id": ANY,
-            "user_id": "UUID",
-            "action": "somepackage-add-started",
-            "client_time": ANY,
-            "metadata": {
-                "args": {"x": 1, "y": 1},
-                "argv": ANY,
-            },
-            "total_runtime": None,
-            "python_version": ANY,
-            "version": "0.1",
-            "package_name": "somepackage",
-            "docker_container": False,
-            "cloud": None,
-            "email": None,
-            "os": ANY,
-            "environment": ANY,
-            "telemetry_version": ANY,
-        },
-    )
 
     expected_second = dict(
         distinct_id="UUID",
@@ -365,8 +236,7 @@ def test_logs_if_error(mock_posthog):
         },
     )
 
-    assert mock_posthog.call_args_list[0][1] == expected_first
-    assert mock_posthog.call_args_list[1][1] == expected_second
+    assert mock_posthog.call_args_list[0][1] == expected_second
 
 
 @pytest.mark.parametrize(
@@ -403,31 +273,6 @@ def test_telemetry_group(mock_posthog, y, y_logged):
 
     expected_first = dict(
         distinct_id="UUID",
-        event="somepackage-SomeObject-add-started",
-        properties={
-            "event_id": ANY,
-            "user_id": "UUID",
-            "action": "somepackage-SomeObject-add-started",
-            "client_time": ANY,
-            "metadata": {
-                "args": {"x": 1, "y": y_logged},
-                "argv": ANY,
-            },
-            "total_runtime": None,
-            "python_version": ANY,
-            "version": "0.1",
-            "package_name": "somepackage",
-            "docker_container": False,
-            "cloud": None,
-            "email": None,
-            "os": ANY,
-            "environment": ANY,
-            "telemetry_version": ANY,
-        },
-    )
-
-    expected_second = dict(
-        distinct_id="UUID",
         event="somepackage-SomeObject-add-success",
         properties={
             "event_id": ANY,
@@ -451,32 +296,7 @@ def test_telemetry_group(mock_posthog, y, y_logged):
         },
     )
 
-    expected_third = dict(
-        distinct_id="UUID",
-        event="somepackage-SomeObject-substract-started",
-        properties={
-            "event_id": ANY,
-            "user_id": "UUID",
-            "action": "somepackage-SomeObject-substract-started",
-            "client_time": ANY,
-            "metadata": {
-                "args": {"x": 1, "y": y_logged},
-                "argv": ANY,
-            },
-            "total_runtime": None,
-            "python_version": ANY,
-            "version": "0.1",
-            "package_name": "somepackage",
-            "docker_container": False,
-            "cloud": None,
-            "email": None,
-            "os": ANY,
-            "environment": ANY,
-            "telemetry_version": ANY,
-        },
-    )
-
-    expected_fourth = dict(
+    expected_second = dict(
         distinct_id="UUID",
         event="somepackage-SomeObject-substract-success",
         properties={
@@ -503,8 +323,6 @@ def test_telemetry_group(mock_posthog, y, y_logged):
 
     assert mock_posthog.call_args_list[0][1] == expected_first
     assert mock_posthog.call_args_list[1][1] == expected_second
-    assert mock_posthog.call_args_list[2][1] == expected_third
-    assert mock_posthog.call_args_list[3][1] == expected_fourth
 
 
 def test_method_with_no_arguments(mock_posthog):
@@ -520,32 +338,7 @@ def test_method_with_no_arguments(mock_posthog):
     obj = SomeObject()
     obj.do_stuff()
 
-    expected_first = dict(
-        distinct_id="UUID",
-        event="somepackage-SomeObject-do-stuff-started",
-        properties={
-            "event_id": ANY,
-            "user_id": "UUID",
-            "action": "somepackage-SomeObject-do-stuff-started",
-            "client_time": ANY,
-            "metadata": {
-                "argv": ANY,
-                "args": {},
-            },
-            "total_runtime": None,
-            "python_version": ANY,
-            "version": "0.1",
-            "package_name": "somepackage",
-            "docker_container": False,
-            "cloud": None,
-            "email": None,
-            "os": ANY,
-            "environment": ANY,
-            "telemetry_version": ANY,
-        },
-    )
-
-    expected_second = dict(
+    expected = dict(
         distinct_id="UUID",
         event="somepackage-SomeObject-do-stuff-success",
         properties={
@@ -570,8 +363,7 @@ def test_method_with_no_arguments(mock_posthog):
         },
     )
 
-    assert mock_posthog.call_args_list[0][1] == expected_first
-    assert mock_posthog.call_args_list[1][1] == expected_second
+    assert mock_posthog.call_args_list[0][1] == expected
 
 
 def test_function_with_no_arguments(mock_posthog):
@@ -585,32 +377,7 @@ def test_function_with_no_arguments(mock_posthog):
 
     do_stuff()
 
-    expected_first = dict(
-        distinct_id="UUID",
-        event="somepackage-do-stuff-started",
-        properties={
-            "event_id": ANY,
-            "user_id": "UUID",
-            "action": "somepackage-do-stuff-started",
-            "client_time": ANY,
-            "metadata": {
-                "argv": ANY,
-                "args": {},
-            },
-            "total_runtime": None,
-            "python_version": ANY,
-            "version": "0.1",
-            "package_name": "somepackage",
-            "docker_container": False,
-            "cloud": None,
-            "email": None,
-            "os": ANY,
-            "environment": ANY,
-            "telemetry_version": ANY,
-        },
-    )
-
-    expected_second = dict(
+    expected = dict(
         distinct_id="UUID",
         event="somepackage-do-stuff-success",
         properties={
@@ -635,8 +402,7 @@ def test_function_with_no_arguments(mock_posthog):
         },
     )
 
-    assert mock_posthog.call_args_list[0][1] == expected_first
-    assert mock_posthog.call_args_list[1][1] == expected_second
+    assert mock_posthog.call_args_list[0][1] == expected
 
 
 def test_function_with_args(mock_posthog):
@@ -650,32 +416,7 @@ def test_function_with_args(mock_posthog):
 
     do_stuff(1, 2, 3)
 
-    expected_first = dict(
-        distinct_id="UUID",
-        event="somepackage-do-stuff-started",
-        properties={
-            "event_id": ANY,
-            "user_id": "UUID",
-            "action": "somepackage-do-stuff-started",
-            "client_time": ANY,
-            "metadata": {
-                "argv": ANY,
-                "args": {"a": 1, "args": 2},
-            },
-            "total_runtime": None,
-            "python_version": ANY,
-            "version": "0.1",
-            "package_name": "somepackage",
-            "docker_container": False,
-            "cloud": None,
-            "email": None,
-            "os": ANY,
-            "environment": ANY,
-            "telemetry_version": ANY,
-        },
-    )
-
-    expected_second = dict(
+    expected = dict(
         distinct_id="UUID",
         event="somepackage-do-stuff-success",
         properties={
@@ -700,8 +441,7 @@ def test_function_with_args(mock_posthog):
         },
     )
 
-    assert mock_posthog.call_args_list[0][1] == expected_first
-    assert mock_posthog.call_args_list[1][1] == expected_second
+    assert mock_posthog.call_args_list[0][1] == expected
 
 
 def test_function_with_kwargs(mock_posthog):
@@ -715,32 +455,7 @@ def test_function_with_kwargs(mock_posthog):
 
     do_stuff(1, b=2, c=3)
 
-    expected_first = dict(
-        distinct_id="UUID",
-        event="somepackage-do-stuff-started",
-        properties={
-            "event_id": ANY,
-            "user_id": "UUID",
-            "action": "somepackage-do-stuff-started",
-            "client_time": ANY,
-            "metadata": {
-                "argv": ANY,
-                "args": {"a": 1, "b": 2, "c": 3},
-            },
-            "total_runtime": None,
-            "python_version": ANY,
-            "version": "0.1",
-            "package_name": "somepackage",
-            "docker_container": False,
-            "cloud": None,
-            "email": None,
-            "os": ANY,
-            "environment": ANY,
-            "telemetry_version": ANY,
-        },
-    )
-
-    expected_second = dict(
+    expected = dict(
         distinct_id="UUID",
         event="somepackage-do-stuff-success",
         properties={
@@ -765,5 +480,4 @@ def test_function_with_kwargs(mock_posthog):
         },
     )
 
-    assert mock_posthog.call_args_list[0][1] == expected_first
-    assert mock_posthog.call_args_list[1][1] == expected_second
+    assert mock_posthog.call_args_list[0][1] == expected


### PR DESCRIPTION
## Describe your changes

when recording telemetry events, we used to store a start and success/fail event. to reduce the number of events, we only trigger success/fail now.

the actual change is just a few lines of code, the rest are tests that had to be updated

once this is approved, I can make a new release

## Issue number

Closes #X

## Checklist before requesting a review

- [ ] Performed a self-review of my code
- [ ] Formatted my code with [`pkgmt format`](https://ploomber-contributing.readthedocs.io/en/latest/contributing/pr.html#linting-formatting)
- [ ] Added [tests](https://ploomber-contributing.readthedocs.io/en/latest/contributing/pr.html#testing) (when necessary).
- [ ] Added [docstring](https://ploomber-contributing.readthedocs.io/en/latest/contributing/pr.html#documenting-changes-and-new-features) documentation and update the [changelog](https://ploomber-contributing.readthedocs.io/en/latest/contributing/pr.html#changelog) (when needed)



<!-- readthedocs-preview ploomber-core start -->
----
:books: Documentation preview :books:: https://ploomber-core--77.org.readthedocs.build/en/77/

<!-- readthedocs-preview ploomber-core end -->