### PR TITLE
check for message attribute

### DIFF
--- a/src/ploomber_core/exceptions.py
+++ b/src/ploomber_core/exceptions.py
@@ -87,6 +87,9 @@ def _add_community_link(e):
     elif COMMUNITY not in e.args[0]:
         message = e.args[0] + COMMUNITY
         e.args = (message,)
+        # Certain exceptions like ClickException have message
+        # as their first parameter. In that case args is not
+        # accessed while raising the error
         if hasattr(e, "message"):
             e.message = message
 

--- a/src/ploomber_core/exceptions.py
+++ b/src/ploomber_core/exceptions.py
@@ -87,6 +87,8 @@ def _add_community_link(e):
     elif COMMUNITY not in e.args[0]:
         message = e.args[0] + COMMUNITY
         e.args = (message,)
+        if hasattr(e, "message"):
+            e.message = message
 
     return e
 

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -54,6 +54,23 @@ def test_modify_exceptions_with_attribute():
     assert exceptions.get_community_link() in str(excinfo.value)
 
 
+def test_modify_exceptions_with_message_attribute():
+    class CustomException(Exception):
+        def __init__(self, message: str) -> None:
+            super().__init__(message)
+            self.message = message
+            self.modify_exception = True
+
+    @exceptions.modify_exceptions
+    def crash():
+        raise CustomException("some message")
+
+    with pytest.raises(CustomException) as excinfo:
+        crash()
+
+    assert exceptions.get_community_link() in str(excinfo.value)
+
+
 def test_modify_exceptions_value_error():
     @exceptions.modify_exceptions
     def crash():


### PR DESCRIPTION
## Describe your changes

Added check for `message` attribute when displaying Slack link. This is required for exceptions which have `message` as their first parameter and not `args`.

## Issue number

Closes #X

## Checklist before requesting a review

- [ ] Performed a self-review of my code
- [ ] Formatted my code with [`pkgmt format`](https://ploomber-contributing.readthedocs.io/en/latest/contributing/pr.html#linting-formatting)
- [ ] Added [tests](https://ploomber-contributing.readthedocs.io/en/latest/contributing/pr.html#testing) (when necessary).
- [ ] Added [docstring](https://ploomber-contributing.readthedocs.io/en/latest/contributing/pr.html#documenting-changes-and-new-features) documentation and update the [changelog](https://ploomber-contributing.readthedocs.io/en/latest/contributing/pr.html#changelog) (when needed)



<!-- readthedocs-preview ploomber-core start -->
----
:books: Documentation preview :books:: https://ploomber-core--81.org.readthedocs.build/en/81/

<!-- readthedocs-preview ploomber-core end -->