### PR TITLE
Fix deprecated Posthog API Key initialization

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,7 +6,7 @@ jobs:
   test:
     strategy:
       matrix:
-        python-version: [3.8, 3.9, '3.10', '3.11']
+        python-version: ['3.10', '3.11', '3.12']
         os: [ubuntu-latest, macos-latest, windows-latest]
 
     runs-on: ${{ matrix.os }}

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -15,3 +15,4 @@ conda:
 sphinx:
   builder: html
   fail_on_warning: true
+  configuration: doc/_config.yml

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ with open("src/ploomber_core/__init__.py", "rb") as f:
 
 REQUIRES = [
     "pyyaml",
-    "posthog",
+    "posthog<3.0",
     'importlib-metadata;python_version<"3.8"',
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ with open("src/ploomber_core/__init__.py", "rb") as f:
 
 REQUIRES = [
     "pyyaml",
-    "posthog<3.0",
+    "posthog>=3.0",
     'importlib-metadata;python_version<"3.8"',
 ]
 

--- a/src/ploomber_core/telemetry/telemetry.py
+++ b/src/ploomber_core/telemetry/telemetry.py
@@ -425,9 +425,11 @@ class Telemetry:
                 api_key, host="https://us.i.posthog.com"
             )
         except Exception as e:
-            # If PostHog initialization fails, create a dummy client
-            warnings.warn(f"Failed to initialize PostHog client: {e}")
-            self._posthog_client = None
+            raise ImportError(
+                "Failed to initialize posthog client. This likely means your posthog "
+                "version is incompatible. To fix this, either upgrade to posthog>=3.0 "
+                "or downgrade to ploomber-core<=0.2.26"
+            ) from e
 
     @classmethod
     def from_package(cls, package_name, *, print_cloud_message=True, api_key=None):

--- a/src/ploomber_core/telemetry/telemetry.py
+++ b/src/ploomber_core/telemetry/telemetry.py
@@ -419,16 +419,6 @@ class Telemetry:
         self.version = version
         self.print_cloud_message = print_cloud_message
 
-        # Initialize Posthog client
-        try:
-            self._posthog_client = posthog.Posthog(
-                api_key, host="https://us.i.posthog.com"
-            )
-        except Exception as e:
-            # If PostHog initialization fails, create a dummy client
-            warnings.warn(f"Failed to initialize PostHog client: {e}")
-            self._posthog_client = None
-
     @classmethod
     def from_package(cls, package_name, *, print_cloud_message=True, api_key=None):
         """
@@ -450,6 +440,9 @@ class Telemetry:
         if missing like timestamp, event id and stats information.
         """
 
+        # This method of setting the API Key is deprecated in PostHog 3.x
+        # PostHog has been pinned to 2.x to avoid breaking changes
+        posthog.project_api_key = self.api_key
         metadata = metadata or {}
 
         event_id = uuid4()
@@ -525,19 +518,12 @@ class Telemetry:
                 "metadata": metadata,
             }
 
-            if self._posthog_client is not None:
-                if is_install:
-                    self._posthog_client.capture(
-                        distinct_id=uid,
-                        event="install_success_indirect",
-                        properties=props,
-                    )
-
-                self._posthog_client.capture(
-                    distinct_id=uid, event=action, properties=props
+            if is_install:
+                posthog.capture(
+                    distinct_id=uid, event="install_success_indirect", properties=props
                 )
-            else:
-                raise RuntimeError("Log call failed: PostHog client not initialized.")
+
+            posthog.capture(distinct_id=uid, event=action, properties=props)
 
     # NOTE: should we log differently depending on the error type?
     # NOTE: how should we handle chained exceptions?

--- a/src/ploomber_core/telemetry/telemetry.py
+++ b/src/ploomber_core/telemetry/telemetry.py
@@ -418,10 +418,12 @@ class Telemetry:
         self.package_name = package_name
         self.version = version
         self.print_cloud_message = print_cloud_message
-        
-        # Initialize PostHog client properly
+
+        # Initialize Posthog client
         try:
-            self._posthog_client = posthog.Posthog(api_key, host='https://us.i.posthog.com')
+            self._posthog_client = posthog.Posthog(
+                api_key, host="https://us.i.posthog.com"
+            )
         except Exception as e:
             # If PostHog initialization fails, create a dummy client
             warnings.warn(f"Failed to initialize PostHog client: {e}")
@@ -526,10 +528,14 @@ class Telemetry:
             if self._posthog_client is not None:
                 if is_install:
                     self._posthog_client.capture(
-                        distinct_id=uid, event="install_success_indirect", properties=props
+                        distinct_id=uid,
+                        event="install_success_indirect",
+                        properties=props,
                     )
 
-                self._posthog_client.capture(distinct_id=uid, event=action, properties=props)
+                self._posthog_client.capture(
+                    distinct_id=uid, event=action, properties=props
+                )
             else:
                 raise RuntimeError("Log call failed: PostHog client not initialized.")
 

--- a/src/ploomber_core/telemetry/telemetry.py
+++ b/src/ploomber_core/telemetry/telemetry.py
@@ -421,7 +421,9 @@ class Telemetry:
 
         # Initialize PostHog client
         try:
-            self._posthog_client = posthog.Posthog(api_key, host='https://us.i.posthog.com')
+            self._posthog_client = posthog.Posthog(
+                api_key, host="https://us.i.posthog.com"
+            )
         except Exception as e:
             # If PostHog initialization fails, create a dummy client
             warnings.warn(f"Failed to initialize PostHog client: {e}")
@@ -526,10 +528,14 @@ class Telemetry:
             if self._posthog_client is not None:
                 if is_install:
                     self._posthog_client.capture(
-                        distinct_id=uid, event="install_success_indirect", properties=props
+                        distinct_id=uid,
+                        event="install_success_indirect",
+                        properties=props,
                     )
 
-                self._posthog_client.capture(distinct_id=uid, event=action, properties=props)
+                self._posthog_client.capture(
+                    distinct_id=uid, event=action, properties=props
+                )
             else:
                 raise RuntimeError("Log call failed: PostHog client not initialized")
 

--- a/src/ploomber_core/telemetry/telemetry.py
+++ b/src/ploomber_core/telemetry/telemetry.py
@@ -418,6 +418,14 @@ class Telemetry:
         self.package_name = package_name
         self.version = version
         self.print_cloud_message = print_cloud_message
+        
+        # Initialize PostHog client properly
+        try:
+            self._posthog_client = posthog.Posthog(api_key, host='https://us.i.posthog.com')
+        except Exception as e:
+            # If PostHog initialization fails, create a dummy client
+            warnings.warn(f"Failed to initialize PostHog client: {e}")
+            self._posthog_client = None
 
     @classmethod
     def from_package(cls, package_name, *, print_cloud_message=True, api_key=None):
@@ -440,7 +448,6 @@ class Telemetry:
         if missing like timestamp, event id and stats information.
         """
 
-        posthog.project_api_key = self.api_key
         metadata = metadata or {}
 
         event_id = uuid4()
@@ -516,12 +523,15 @@ class Telemetry:
                 "metadata": metadata,
             }
 
-            if is_install:
-                posthog.capture(
-                    distinct_id=uid, event="install_success_indirect", properties=props
-                )
+            if self._posthog_client is not None:
+                if is_install:
+                    self._posthog_client.capture(
+                        distinct_id=uid, event="install_success_indirect", properties=props
+                    )
 
-            posthog.capture(distinct_id=uid, event=action, properties=props)
+                self._posthog_client.capture(distinct_id=uid, event=action, properties=props)
+            else:
+                raise RuntimeError("Log call failed: PostHog client not initialized.")
 
     # NOTE: should we log differently depending on the error type?
     # NOTE: how should we handle chained exceptions?

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -83,5 +83,10 @@ def external_access(request, monkeypatch_session):
         # https://github.com/pytest-dev/pytest/issues/7061#issuecomment-611892868
         external_access = MagicMock()
         external_access.get_something = MagicMock(return_value="Mock was used.")
-        monkeypatch_session.setattr(posthog, "capture", external_access.get_something)
+
+        mock_posthog_instance = MagicMock()
+        mock_posthog_instance.capture = external_access.get_something
+        mock_posthog_class = MagicMock(return_value=mock_posthog_instance)
+
+        monkeypatch_session.setattr(posthog, "Posthog", mock_posthog_class)
         yield

--- a/tests/telemetry/test_telemetry.py
+++ b/tests/telemetry/test_telemetry.py
@@ -826,7 +826,11 @@ def test_hides_posthog_log(caplog, monkeypatch):
         log = logging.getLogger("posthog")
         log.error("some error happened")
 
-    monkeypatch.setattr(posthog, "capture", fake_capture)
+    mock_posthog_instance = Mock()
+    mock_posthog_instance.capture = fake_capture
+    mock_posthog_class = Mock(return_value=mock_posthog_instance)
+
+    monkeypatch.setattr(posthog, "Posthog", mock_posthog_class)
     _telemetry = telemetry.Telemetry(MOCK_API_KEY, "ploomber", "0.14.0")
 
     with caplog.at_level(logging.ERROR, logger="posthog"):
@@ -838,8 +842,12 @@ def test_hides_posthog_log(caplog, monkeypatch):
 # TODO: test more of the values (I'm adding ANY to many of them)
 def test_log_api_stored_values(monkeypatch):
     mock_info = Mock(return_value=(True, "fake-uuid", False))
-    mock = Mock()
-    monkeypatch.setattr(telemetry.posthog, "capture", mock)
+    mock_capture = Mock()
+    mock_posthog_instance = Mock()
+    mock_posthog_instance.capture = mock_capture
+    mock_posthog_class = Mock(return_value=mock_posthog_instance)
+
+    monkeypatch.setattr(telemetry.posthog, "Posthog", mock_posthog_class)
     monkeypatch.setattr(telemetry, "_get_telemetry_info", mock_info)
 
     _telemetry = telemetry.Telemetry(MOCK_API_KEY, "some-package", "1.2.2")
@@ -851,7 +859,7 @@ def test_log_api_stored_values(monkeypatch):
         f"{sys.version_info.micro}"
     )
 
-    mock.assert_called_once_with(
+    mock_capture.assert_called_once_with(
         distinct_id="fake-uuid",
         event="some-action",
         properties={
@@ -876,8 +884,12 @@ def test_log_api_stored_values(monkeypatch):
 
 def test_log_call_stored_values(monkeypatch):
     mock_info = Mock(return_value=(True, "fake-uuid", False))
-    mock = Mock()
-    monkeypatch.setattr(telemetry.posthog, "capture", mock)
+    mock_capture = Mock()
+    mock_posthog_instance = Mock()
+    mock_posthog_instance.capture = mock_capture
+    mock_posthog_class = Mock(return_value=mock_posthog_instance)
+
+    monkeypatch.setattr(telemetry.posthog, "Posthog", mock_posthog_class)
     monkeypatch.setattr(telemetry, "_get_telemetry_info", mock_info)
     monkeypatch.setattr(telemetry.sys, "argv", ["/path/to/bin", "arg2", "arg2"])
 
@@ -894,7 +906,7 @@ def test_log_call_stored_values(monkeypatch):
         f"{sys.version_info.micro}"
     )
 
-    assert mock.call_args_list == [
+    assert mock_capture.call_args_list == [
         call(
             distinct_id="fake-uuid",
             event="some-package-some-action-success",

--- a/tests/telemetry/test_telemetry_log_args.py
+++ b/tests/telemetry/test_telemetry_log_args.py
@@ -7,10 +7,14 @@ from ploomber_core.telemetry import telemetry as telemetry_module
 @pytest.fixture
 def mock_posthog(monkeypatch):
     mock_info = Mock(return_value=(True, "UUID", False))
-    mock = Mock()
-    monkeypatch.setattr(telemetry_module.posthog, "capture", mock)
+    mock_capture = Mock()
+    mock_posthog_instance = Mock()
+    mock_posthog_instance.capture = mock_capture
+    mock_posthog_class = Mock(return_value=mock_posthog_instance)
+
+    monkeypatch.setattr(telemetry_module.posthog, "Posthog", mock_posthog_class)
     monkeypatch.setattr(telemetry_module, "_get_telemetry_info", mock_info)
-    yield mock
+    yield mock_capture
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Describe your changes
- CLI was throwing an error when making telemetry calls due to the Posthog key not being initialized
- We can no longer set the posthog API key via `posthog.project_api_key = self.api_key` since its deprecated
- Updated the initialization to `posthog.Posthog(api_key, host='https://us.i.posthog.com')` and changed the `log_api` function to use this client

## Issue number

Fixes support issue: https://ploomber-io.slack.com/archives/C08QNPDF15J/p1752779413170409

## Checklist before requesting a review

- [ ] Performed a self-review of my code
- [ ] Formatted my code with [`pkgmt format`](https://ploomber-contributing.readthedocs.io/en/latest/contributing/pr.html#linting-formatting)
- [ ] Added [tests](https://ploomber-contributing.readthedocs.io/en/latest/contributing/pr.html#testing) (when necessary).
- [ ] Added [docstring](https://ploomber-contributing.readthedocs.io/en/latest/contributing/pr.html#documenting-changes-and-new-features) documentation and update the [changelog](https://ploomber-contributing.readthedocs.io/en/latest/contributing/pr.html#changelog) (when needed)



<!-- readthedocs-preview ploomber-core start -->
----
📚 Documentation preview 📚: https://ploomber-core--91.org.readthedocs.build/en/91/

<!-- readthedocs-preview ploomber-core end -->